### PR TITLE
UPGRADE: CLICK TO CLIPBOARD, OVERFLOW, DESCRIPTION

### DIFF
--- a/dist/jsonview.bundle.css
+++ b/dist/jsonview.bundle.css
@@ -1,50 +1,99 @@
-.json-container {
-  font-family: 'Open Sans';
-  font-size: 16px;
-  background-color: #fff;
-  color: #808080;
-  box-sizing: border-box; }
-  .json-container .line {
-    margin: 4px 0;
-    display: flex;
-    justify-content: flex-start; }
-  .json-container .caret-icon {
-    width: 18px;
-    text-align: center;
-    cursor: pointer; }
-  .json-container .empty-icon {
-    width: 18px; }
-  .json-container .json-type {
-    margin-right: 4px;
-    margin-left: 4px; }
-  .json-container .json-key {
-    color: #444;
-    margin-right: 4px;
-    margin-left: 4px; }
-  .json-container .json-index {
-    margin-right: 4px;
-    margin-left: 4px; }
-  .json-container .json-value {
-    margin-left: 8px; }
-  .json-container .json-number {
-    color: #f9ae58; }
-  .json-container .json-boolean {
-    color: #ec5f66; }
-  .json-container .json-string {
-    color: #86b25c; }
-  .json-container .json-size {
-    margin-right: 4px;
-    margin-left: 4px; }
-  .json-container .hide {
-    display: none; }
-  .json-container .fas {
-    display: inline-block;
-    width: 0;
-    height: 0;
-    border-style: solid; }
-  .json-container .fa-caret-down {
-    border-width: 6px 5px 0 5px;
-    border-color: #808080 transparent; }
-  .json-container .fa-caret-right {
-    border-width: 5px 0 5px 6px;
-    border-color: transparent transparent transparent #808080; }
+.jsonview-json-container {
+	font-family: 'Open Sans';
+	font-size: 14px;
+	background-color: #fff;
+	color: #808080;
+	box-sizing: border-box;
+}
+
+.jsonview-line {
+	margin: 4px 0;
+	display: flex;
+	justify-content: flex-start;
+}
+
+.jsonview-caret-icon {
+	width: 18px;
+	text-align: center;
+	cursor: pointer;
+}
+
+.jsonview-empty-icon {
+	width: 18px;
+}
+
+.jsonview-json-type {
+	margin-right: 4px;
+	margin-left: 4px;
+}
+
+.jsonview-json-key {
+	color: #444;
+	margin-right: 4px;
+	margin-left: 4px;
+}
+
+.jsonview-json-index {
+	margin-right: 4px;
+	margin-left: 4px;
+}
+
+.jsonview-json-separator {
+
+}
+
+.json-value {
+	margin-left: 8px;
+}
+
+.jsonview-json-number {
+	color: #f9ae58;
+}
+
+.jsonview-json-boolean {
+	color: #ec5f66;
+}
+
+.jsonview-json-string {
+	color: #86b25c;
+}
+
+.jsonview-json-string ::-webkit-scrollbar {
+	display: none;
+}
+
+.jsonview-json-size {
+	margin-right: 4px;
+	margin-left: 4px;
+	justify-content: center;
+	font-size: 0.8em;
+}
+
+.jsonview-hide {
+	display: none;
+}
+
+.jsonview-fas {
+	display: inline-block;
+	width: 0;
+	height: 0;
+}
+
+.fa-caret-down {
+	border-width: 6px 5px 0 5px;
+	border-color: #808080 transparent;
+}
+
+.fa-caret-right {
+	border-width: 5px 0 5px 6px;
+	border-color: transparent transparent transparent #808080;
+}
+
+.jsonview-info-text {
+	text-align: center;
+	font-size: 1em;
+	background-color: #fff;
+	align-content: center;
+	margin-bottom: 0;
+	padding: 5px;
+}

--- a/dist/jsonview.bundle.js
+++ b/dist/jsonview.bundle.js
@@ -1,6 +1,11 @@
 var JsonView = (function (exports) {
   'use strict';
 
+  var input_json;
+  var input_json_name;
+  var tree_root;
+  var occurence = 0;
+
   function _typeof(obj) {
     "@babel/helpers - typeof";
 
@@ -21,20 +26,23 @@ var JsonView = (function (exports) {
     var params = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     var key = params.key,
         size = params.size;
-    return "\n    <div class=\"line\">\n      <div class=\"caret-icon\"><i class=\"fas fa-caret-right\"></i></div>\n      <div class=\"json-key\">".concat(key, "</div>\n      <div class=\"json-size\">").concat(size, "</div>\n    </div>\n  ");
+    return "\n    <div class=\"jsonview-line\">\n      <div class=\"jsonview-caret-icon\"><i class=\"fas fa-caret-right\"></i></div>\n      <div class=\"jsonview-json-key\">".concat(key, "</div>\n      <div class=\"jsonview-json-size\">").concat(size, "</div>\n    </div>\n  ");
   }
 
   function notExpandedTemplate() {
     var params = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     var key = params.key,
-        value = params.value,
-        type = params.type;
-    return "\n    <div class=\"line\">\n      <div class=\"empty-icon\"></div>\n      <div class=\"json-key\">".concat(key, "</div>\n      <div class=\"json-separator\">:</div>\n      <div class=\"json-value json-").concat(type, "\">").concat(value, "</div>\n    </div>\n  ");
+        type = params.type,
+        value = params.value;
+    if (params.type === "string" && params.value.includes("-----BEGIN CERTIFICATE-----")) {
+      value = "<pre style='font-family: 'Courier', sans-serif;' class='jsonview-json-value jsonview-json-".concat(type,"' >",value, "</pre>");
+    }
+    return "\n    <div class=\"jsonview-line\">\n      <div class=\"jsonview-empty-icon\"></div>\n      <div class=\"jsonview-json-key\">".concat(key, "</div>\n      <div class=\"jsonview-json-separator \">:</div>\n      <div class=\"jsonview-json-value jsonview-json-").concat(type, "\">").concat(value, "</div>\n    </div>\n  ");
   }
 
   function hideNodeChildren(node) {
     node.children.forEach(function (child) {
-      child.el.classList.add('hide');
+      child.el.classList.add('jsonview-hide');
 
       if (child.isExpanded) {
         hideNodeChildren(child);
@@ -44,7 +52,7 @@ var JsonView = (function (exports) {
 
   function showNodeChildren(node) {
     node.children.forEach(function (child) {
-      child.el.classList.remove('hide');
+      child.el.classList.remove('jsonview-hide');
 
       if (child.isExpanded) {
         showNodeChildren(child);
@@ -86,7 +94,7 @@ var JsonView = (function (exports) {
 
   function createContainerElement() {
     var el = document.createElement('div');
-    el.className = 'json-container';
+    el.className = 'jsonview-json-container';
     return el;
   }
 
@@ -95,8 +103,9 @@ var JsonView = (function (exports) {
 
     var getSizeString = function getSizeString(node) {
       var len = node.children.length;
-      if (node.type === 'array') return "[".concat(len, "]");
-      if (node.type === 'object') return "{".concat(len, "}");
+      if (node.type === 'array' || node.type === 'object'){
+        return "(".concat(len, ")");
+      }
       return null;
     };
 
@@ -105,14 +114,30 @@ var JsonView = (function (exports) {
         key: node.key,
         size: getSizeString(node)
       });
-      var caretEl = el.querySelector('.caret-icon');
+      var caretEl = el.querySelector('.jsonview-caret-icon');
       caretEl.addEventListener('click', function () {
         toggleNode(node);
       });
     } else {
+      var element_delimiter;
+      switch (node.type) {
+        case "object":
+          element_delimiter = ["{", "}"];
+          break;
+        case "array":
+          element_delimiter = ["[", "]"];
+          break;
+      }
+
+      var node_value = node.value;
+      if (node.type === "object" || node.type === "array"){
+        var empty_object = '<span>'.concat(element_delimiter[0], '<span class="font-italic">', " empty ", '</span>', element_delimiter[1], '</span>');
+        node_value = empty_object;
+      }
+
       el.innerHTML = notExpandedTemplate({
         key: node.key,
-        value: node.value,
+        value: node_value,
         type: _typeof(node.value)
       });
     }
@@ -120,7 +145,7 @@ var JsonView = (function (exports) {
     var lineEl = el.children[0];
 
     if (node.parent !== null) {
-      lineEl.classList.add('hide');
+      lineEl.classList.add('jsonview-hide');
     }
 
     lineEl.style = 'margin-left: ' + node.depth * 18 + 'px;';
@@ -175,11 +200,13 @@ var JsonView = (function (exports) {
     }
   }
 
-  function createTree(jsonData) {
+  function createTree(jsonData, name) {
+    input_json_name = name;
+    input_json = jsonData;
     var data = typeof jsonData === 'string' ? JSON.parse(jsonData) : jsonData;
     var rootNode = createNode({
       value: data,
-      key: getDataType(data),
+      key: name,
       type: getDataType(data)
     });
     createSubnode(data, rootNode);
@@ -194,6 +221,7 @@ var JsonView = (function (exports) {
   }
 
   function render(tree, targetElement) {
+    tree_root = targetElement;
     var containerEl = createContainerElement();
     traverseTree(tree, function (node) {
       node.el = createNodeElement(node);
@@ -204,7 +232,7 @@ var JsonView = (function (exports) {
 
   function expandChildren(node) {
     traverseTree(node, function (child) {
-      child.el.classList.remove('hide');
+      child.el.classList.remove('jsonview-hide');
       child.isExpanded = true;
       setCaretIconDown(child);
     });
@@ -213,9 +241,163 @@ var JsonView = (function (exports) {
   function collapseChildren(node) {
     traverseTree(node, function (child) {
       child.isExpanded = false;
-      if (child.depth > node.depth) child.el.classList.add('hide');
+      if (child.depth > node.depth) {
+        child.el.classList.add('jsonview-hide');
+      }
       setCaretIconRight(child);
     });
+  }
+
+  function allowOverflow() {
+    const tree = document.getElementsByClassName("jsonview-json-value jsonview-json-string");
+
+    if (tree.length > 0){
+      for (var i = 0; i < tree.length; i++) {
+        tree[i].addEventListener("mouseover", function () {
+          this.style.overflow = "auto";
+        });
+        tree[i].addEventListener("mouseleave", function () {
+          this.style.overflow = "";
+        });
+      }
+    }
+  }
+
+  function getLeaf(object, leaf, max_occurence){
+    if(object !== null && object.hasOwnProperty(leaf)) {
+        occurence++;
+        if (max_occurence === occurence){
+          return object[leaf];
+        }
+    }
+    for(var i=0; i <Object.keys(object).length; i++){
+        var node = object[Object.keys(object)[i]];
+        if(node !== null && typeof node === "object"){
+            var o = getLeaf(object[Object.keys(object)[i]], leaf, max_occurence);
+            if(o !== false){
+                return o;
+            }
+        }
+    }
+
+    return false;
+}
+
+function countOccurences(el, key_name) {
+    var counter = 0;
+    var root_tree = el.parentNode.parentNode;
+    for (var j = 0; j < root_tree.children.length; j++){
+      // We count the number of time this key name exists above what we clicked on
+      if (root_tree.children.length > 0) {
+        var text_element = root_tree.children[j].children[1];
+        if (text_element.innerText === key_name){
+          counter++;
+        }
+        // We stop if we encounter what we clicked on
+        if (text_element === el){
+          break;
+        }
+      }
+    }
+    return counter;
+}
+
+  function allowClickToClipboard() {
+
+    // Copy the whole object corresponding to the object the user clicked on
+    var objects = document.getElementsByClassName("jsonview-caret-icon");
+    if (objects.length > 0) {
+      for (var i = 0; i < objects.length; i++) {
+
+        // Each node in the JSON
+        objects[i].parentNode.children[1].addEventListener("click", function () {
+          var object_clicked;
+
+          // If it corresponds to the root of our json
+          if (this.innerText === input_json_name) {
+            object_clicked = input_json;
+          } else {
+            // The key of the object the user clicked on
+            var key_name = this.innerText;
+
+            // We need to count the number of time this key appears because otherwise
+            // we might the wrong key with this name.
+            // We use this in order to know when we can skip the keys that have this name in our json
+            var counter = countOccurences(this, key_name);
+
+            // We use recursion in order to find the object we are looking for
+            // (cautions: this script is backward compatible with old js.
+            //  Please take that in mind when coding - Emile D)
+            occurence = 0; // reset the counter of getLeaf
+            object_clicked = getLeaf(input_json, key_name, counter);
+          }
+
+          var el = this;
+          var old_el_color = el.style.color;
+          if (object_clicked !== false){
+            navigator.clipboard.writeText(JSON.stringify(object_clicked));
+
+            // We succeeded, we show it to the user
+            el.style.color = "#00FF00";
+            setTimeout(function () {
+              el.style.color = old_el_color;
+            }, 1000);
+
+          }else{
+            // If an error occured, we change the color to red
+            el.style.color = "#FF0000";
+            var old_val = el.innerText;
+            el.innerText = "Error";
+            setTimeout(function () {
+              el.style.color = old_el_color;
+              el.innerText = old_val;
+            }, 1000);
+          }
+        });
+      }
+    }
+
+    // Copy the value of a specific line
+    const lines = document.querySelectorAll(".jsonview-line > .jsonview-empty-icon");
+    if (lines.length > 0) {
+      for (var i = 0; i < lines.length; i++) {
+        var line = lines[i].parentNode;
+
+        // When the user clicks on a line
+        line.addEventListener("click", function (){
+          var node_value = this.children[3];
+
+          // Sometimes we have a <pre></pre> element
+          var value = node_value.innerText;
+          if (node_value.children.length > 0) {
+            value = node_value.children[0].innerText;
+          }
+
+          // Save to clipboard
+          navigator.clipboard.writeText(value);
+
+          // Give feedback to the user
+          var el_key = this.children[1];
+          var el_value = this.children[3];
+
+          var old_el_key_color = el_key.style.color;
+          el_key.style.color = "#00FF00";
+          var old_el_value_color = el_value.style.color;
+          el_value.style.color = "#00FF00";
+          setTimeout(function () {
+            el_key.style.color = old_el_key_color;
+            el_value.style.color = old_el_value_color;
+          }, 1000);
+        });
+      }
+    }
+  }
+
+  function setDescription(message) {
+    var text = document.createElement("p");
+    text.className = "jsonview-info-text";
+    text.innerText = message;
+    tree_root.prepend(text);
   }
 
   exports.collapseChildren = collapseChildren;
@@ -224,6 +406,11 @@ var JsonView = (function (exports) {
   exports.render = render;
   exports.renderJSON = renderJSON;
   exports.traverseTree = traverseTree;
+
+  // Added by EDU
+  exports.allowOverflow = allowOverflow;
+  exports.allowClickToClipboard = allowClickToClipboard;
+  exports.setDescription = setDescription;
 
   return exports;
 


### PR DESCRIPTION
Those are the optional features added:
- Clicking on a node or key/value will copy its content:
    > Clicking on a node will copy the object to the user's clipboard
    > Clicking on a key/value will copy the value
 - Auto overflow: when the mouse overs a value, it sets: overflow=auto
    > Useful if the value goes outside of the screen
 - Set a description above the JSON tree

Had to rename CSS classes due to a conflict with other frameworks.

Notes:
The click-to-clipboard feature works well but has a minor limitation:
If a key/node's name appears twice in the same json: possible mistake.
The wrong value can be copied
This can be corrected fairly easily.
But I do not have the time currently.